### PR TITLE
Mantis#1056123

### DIFF
--- a/playbooks/06 - IRP - Case Management/Alert - [02] Capture Ack SLA (Upon Update).json
+++ b/playbooks/06 - IRP - Case Management/Alert - [02] Capture Ack SLA (Upon Update).json
@@ -342,7 +342,7 @@
                     {
                         "option": "Set Ack Date",
                         "step_iri": "\/api\/3\/workflow_steps\/8386bc90-78a0-46b2-b33f-655c697b24d2",
-                        "condition": "{{ vars.input.records[0].status.itemValue == vars.steps.Get_SLA_Details.sla_time_list.alertAackTrackedOn }}",
+                        "condition": "{{ (vars.input.records[0].status.itemValue == vars.steps.Get_SLA_Details.sla_time_list.alertAackTrackedOn) or (vars.input.records[0].ackSlaStatus.itemValue == 'Awaiting Action' and vars.input.records[0].status.itemValue == 'Closed') }}",
                         "step_name": "Check Acknowledge SLA Status"
                     },
                     {
@@ -351,7 +351,8 @@
                         "step_iri": "\/api\/3\/workflow_steps\/084b0d14-e47e-4cc5-9a12-79bbd46d5014",
                         "step_name": "Recalculate Ack SLA"
                     }
-                ]
+                ],
+                "step_variables": []
             },
             "status": null,
             "top": "435",


### PR DESCRIPTION
### Mantis#1056123
- **Description:** When an alert's status is updated directly from "Open" to "Closed," the acknowledgement SLA is not calculated, causing the timer to keep running and the SLA to remain in "Awaiting Action" status.  

- **Preconditions:**  
  - An alert is in "Open" status.  
  - The acknowledgement SLA is in "Awaiting Action" status.  
  - The alert is updated directly to "Closed" without transitioning through "Acknowledged."  

- **Steps:**  
  1. Update an alert's status directly from "Open" to "Closed."  
  2. Observe the acknowledgment SLA status.  

- **Actual Result:** The acknowledgement SLA remains in "Awaiting Action" status, and the timer continues running.  
- **Expected Result:** The acknowledgement SLA is calculated correctly, and its status is updated accordingly.