### PR TITLE
BugFixes#2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 - **Certified**: Yes 
 - **Publisher**: Fortinet 
 - **Compatible Version**: FortiSOAR 7.6.0 and later 
+- [Release Notes](./release_notes.md)
  
 
 # Overview 

--- a/playbooks/06 - IRP - Case Management/Alert - Update SLA Details.json
+++ b/playbooks/06 - IRP - Case Management/Alert - Update SLA Details.json
@@ -1,4 +1,5 @@
 {
+    "@context": "\/api\/3\/contexts\/Workflow",
     "@type": "Workflow",
     "triggerLimit": null,
     "name": "Alert - Update SLA Details",
@@ -138,7 +139,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
+            "top": "705",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
@@ -197,7 +198,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "840",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -244,13 +245,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Calculate Response SLA -> Update SLA",
-            "targetStep": "\/api\/3\/workflow_steps\/78ebe527-de83-43be-9550-d952b23f26b7",
+            "name": "Calculate Response SLA -> Note for Default SLA",
+            "targetStep": "\/api\/3\/workflow_steps\/ab73a40a-39cc-411d-9be1-774040beaa83",
             "sourceStep": "\/api\/3\/workflow_steps\/5f38fc54-a5ea-4f7c-a0e6-dfd8231bf485",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "01b47abd-7d94-4a51-80bc-c1d91152cfbf"
+            "uuid": "a4181ee5-a6b6-4118-90c9-88a517fe3df5"
         },
         {
             "@type": "WorkflowRoute",
@@ -264,6 +265,16 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Note for Default SLA -> Update SLA",
+            "targetStep": "\/api\/3\/workflow_steps\/78ebe527-de83-43be-9550-d952b23f26b7",
+            "sourceStep": "\/api\/3\/workflow_steps\/ab73a40a-39cc-411d-9be1-774040beaa83",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "49a09970-042a-421b-b9b5-9dd0b8e6fcb6"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Start -> GET SLA",
             "targetStep": "\/api\/3\/workflow_steps\/577b4fa8-b0aa-4cd0-95d5-50ed8a8b3a48",
             "sourceStep": "\/api\/3\/workflow_steps\/e184dde0-72cd-4daf-ad51-e9861f0244ff",
@@ -271,16 +282,6 @@
             "isExecuted": false,
             "group": null,
             "uuid": "aae07c04-0a33-4ae4-b4f4-468f694397ff"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Update SLA -> Note for Default SLA",
-            "targetStep": "\/api\/3\/workflow_steps\/ab73a40a-39cc-411d-9be1-774040beaa83",
-            "sourceStep": "\/api\/3\/workflow_steps\/78ebe527-de83-43be-9550-d952b23f26b7",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "41ef2ab7-3b5f-46b7-9980-32e2b0fe2bd1"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/06 - IRP - Case Management/Alert - Update SLA Details.json
+++ b/playbooks/06 - IRP - Case Management/Alert - Update SLA Details.json
@@ -177,11 +177,11 @@
             "description": null,
             "arguments": {
                 "resource": {
-                    "dueBy": "{%if vars.steps.Calculate_Ack_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Calculate_Ack_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}",
+                    "dueBy": "{%if vars.steps.Calculate_Acknowledge_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Calculate_Acknowledge_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}",
                     "__link": {
                         "recordTags": "{% if vars.sla_time_list.defaultSLA %}Default SLA{% endif %}"
                     },
-                    "respDueDate": "{%if vars.steps.Calculate_Resp_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Calculate_Resp_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}",
+                    "respDueDate": "{%if vars.steps.Calculate_Response_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Calculate_Response_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}",
                     "ackSlaStatus": "{%if vars.sla_time_list.alertAckTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}",
                     "respSlaStatus": "{%if vars.sla_time_list.alertResTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}"
                 },

--- a/playbooks/06 - IRP - Case Management/Alert - [01] Capture All SLA (Upon Create).json
+++ b/playbooks/06 - IRP - Case Management/Alert - [01] Capture All SLA (Upon Create).json
@@ -1,4 +1,5 @@
 {
+    "@context": "\/api\/3\/contexts\/Workflow",
     "@type": "Workflow",
     "triggerLimit": null,
     "name": "Alert - [01] Capture All SLA (Upon Create)",
@@ -85,8 +86,8 @@
                 "workflowReference": "\/api\/3\/workflows\/ef9acc85-0610-45f5-a0ca-fe6b06d53e0a"
             },
             "status": null,
-            "top": "160",
-            "left": "120",
+            "top": "165",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "794cd6ac-ce09-4fa3-af8f-42005b3ec404"

--- a/playbooks/06 - IRP - Case Management/Alert - [02] Capture Ack SLA (Upon Update).json
+++ b/playbooks/06 - IRP - Case Management/Alert - [02] Capture Ack SLA (Upon Update).json
@@ -131,7 +131,7 @@
                     "ackSlaStatus": "{% if vars.input.records[0].dueBy < vars.input.records[0].modifyDate%}{{\"SLAState\" | picklist(\"Missed\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Paused\", \"@id\")}}{%endif%}",
                     "respSlaStatus": "\/api\/3\/picklists\/3f4ef2dc-7f56-4886-b215-ee08b344cbdf",
                     "ackSLApausedon": "{{globalVars.Current_Date}}",
-                    "alertRemainingAckSLA": "{{vars.steps.Calculate_Time_Left_for_Ack_before_Pausing.data['minutes_left'] | int}}"
+                    "alertRemainingAckSLA": "{{vars.steps.Calculate_Time_Left_for_Acknowledge_before_Pausing.data['minutes_left'] | int}}"
                 },
                 "_showJson": false,
                 "operation": "Append",
@@ -183,7 +183,7 @@
             "arguments": {
                 "when": "{{(vars.input.records[0].ackSlaStatus.itemValue == \"Awaiting Action\" or vars.input.records[0].ackSlaStatus.itemValue == \"Paused\" ) and vars.input.records[0].status.itemValue != \"Closed\"}}",
                 "resource": {
-                    "dueBy": "{{vars.steps.Recalculate_Ack_SLA.data['sla_due_date_timestamp']}}",
+                    "dueBy": "{{vars.steps.Recalculate_Acknowledge_SLA.data['sla_due_date_timestamp']}}",
                     "ackSlaStatus": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818"
                 },
                 "_showJson": false,

--- a/playbooks/06 - IRP - Case Management/Alert - [02] Capture Ack SLA (Upon Update).json
+++ b/playbooks/06 - IRP - Case Management/Alert - [02] Capture Ack SLA (Upon Update).json
@@ -1,4 +1,5 @@
 {
+    "@context": "\/api\/3\/contexts\/Workflow",
     "@type": "Workflow",
     "triggerLimit": null,
     "name": "Alert - [02] Capture Acknowledge SLA (Upon Update)",
@@ -35,7 +36,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "435",
+            "top": "705",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
@@ -59,7 +60,7 @@
                 "workflowReference": "\/api\/3\/workflows\/45096dd1-6f64-4f86-937f-711a1054d436"
             },
             "status": null,
-            "top": "165",
+            "top": "435",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -74,20 +75,20 @@
                     {
                         "option": "Missed",
                         "step_iri": "\/api\/3\/workflow_steps\/a7e1b006-d4af-4e6d-ad37-76940f2b490f",
-                        "condition": "{{ vars.input.records[0].modifyDate > vars.input.records[0].dueBy }}",
+                        "condition": "{{ vars.input.records[0].modifyDate > vars.ack_due_date }}",
                         "step_name": "Set Acknowledge SLA as Missed"
                     },
                     {
                         "option": "Met",
                         "step_iri": "\/api\/3\/workflow_steps\/c73720f8-10c9-46d7-ba3b-7da00c99117f",
-                        "condition": "{{ vars.input.records[0].modifyDate <  vars.input.records[0].dueBy }}",
+                        "condition": "{{ vars.input.records[0].modifyDate < vars.ack_due_date }}",
                         "step_name": "Set Acknowledge SLA as Met"
                     }
                 ],
                 "step_variables": []
             },
             "status": null,
-            "top": "570",
+            "top": "840",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -115,7 +116,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "300",
+            "top": "570",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -144,7 +145,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "570",
+            "top": "840",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -170,7 +171,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "570",
+            "top": "840",
             "left": "1000",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
@@ -197,7 +198,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "975",
             "left": "1000",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -235,7 +236,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "975",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -272,7 +273,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "975",
             "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -287,14 +288,17 @@
                 "resources": [
                     "alerts"
                 ],
+                "__triggerLimit": true,
                 "step_variables": {
                     "input": {
                         "params": [],
                         "records": [
                             "{{vars.input.records[0]}}"
                         ]
-                    }
+                    },
+                    "ack_due_date": "{{vars.input.records[0].dueBy or false}}"
                 },
+                "triggerOnSource": true,
                 "fieldbasedtrigger": {
                     "sort": [],
                     "limit": 30,
@@ -327,7 +331,8 @@
                             "previousTemplate": "multiselectpicklist"
                         }
                     ]
-                }
+                },
+                "triggerOnReplicate": false
             },
             "status": null,
             "top": "30",
@@ -358,11 +363,96 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "435",
+            "top": "705",
             "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "b3e774bc-69e1-4067-a78e-e1d01f59da2a"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update SLA Details",
+            "description": null,
+            "arguments": {
+                "when": "{{not vars.ack_due_date}}",
+                "arguments": {
+                    "alert_id": "{{vars.input.records[0]['@id']}}",
+                    "severity": "{{vars.input.records[0].severity.itemValue}}",
+                    "tenant_iri": "{{vars.input.records[0].tenant['@id'] | ternary(vars.input.records[0].tenant['@id'], none)}}",
+                    "alert_crt_dt": "{{vars.input.records[0].createDate}}"
+                },
+                "apply_async": false,
+                "step_variables": {
+                    "ack_due_date": "{{vars.steps.Update_SLA_Details.dueBy}}"
+                },
+                "pass_parent_env": false,
+                "pass_input_record": false,
+                "workflowReference": "\/api\/3\/workflows\/ef9acc85-0610-45f5-a0ca-fe6b06d53e0a"
+            },
+            "status": null,
+            "top": "300",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "b70a1c41-8ae2-4935-b0a8-560fd87cc412"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Wait for Acknowledge Due Date",
+            "description": null,
+            "arguments": {
+                "when": "{{not vars.ack_due_date}}",
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "uuid",
+                            "value": "{{vars.input.records[0].uuid}}",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "type": "datetime",
+                                    "field": "dueBy",
+                                    "value": "false",
+                                    "operator": "isnull"
+                                },
+                                {
+                                    "type": "datetime",
+                                    "field": "dueBy",
+                                    "value": "null",
+                                    "operator": "isnull"
+                                }
+                            ]
+                        }
+                    ],
+                    "__selectFields": [
+                        "dueBy"
+                    ]
+                },
+                "module": "alerts?$limit=30",
+                "do_until": {
+                    "delay": 1,
+                    "retries": 30,
+                    "condition": "{{vars.steps.Wait_for_Acknowledge_Due_Date | length > 0}}"
+                },
+                "checkboxFields": true,
+                "step_variables": {
+                    "ack_due_date": "{% if vars.steps.Wait_for_Acknowledge_Due_Date | length > 0 %}{{vars.steps.Wait_for_Acknowledge_Due_Date[0].dueBy}}{% else %}false{% endif %}"
+                }
+            },
+            "status": null,
+            "top": "165",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "2abd1e97-4e8b-4907-9f47-e20f52ecc4a0"
         }
     ],
     "routes": [
@@ -408,13 +498,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Get SLA Details -> Is Pending",
+            "name": "Get SLA Details -> Is Acknowledge SLA Paused",
             "targetStep": "\/api\/3\/workflow_steps\/4b47d563-2b8e-47c0-aee6-8c47bb23db0c",
             "sourceStep": "\/api\/3\/workflow_steps\/0442c07a-96d8-4d43-a984-4def4fb61db1",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "d3a374fb-4c95-4f52-ba93-a415b6b630cc"
+            "uuid": "090bbb1a-0dbe-40e6-b000-c9c412da4f2b"
         },
         {
             "@type": "WorkflowRoute",
@@ -438,13 +528,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> Get SLA Details",
-            "targetStep": "\/api\/3\/workflow_steps\/0442c07a-96d8-4d43-a984-4def4fb61db1",
+            "name": "Start -> Wait for Acknowledge Due Date",
+            "targetStep": "\/api\/3\/workflow_steps\/2abd1e97-4e8b-4907-9f47-e20f52ecc4a0",
             "sourceStep": "\/api\/3\/workflow_steps\/0968f9df-27b7-4720-acd9-4b48223ffd6f",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "961e7c89-7e83-40d3-af1b-5e27fee21b93"
+            "uuid": "333fcb0f-f7aa-4a47-91b9-cb5065e58a8e"
         },
         {
             "@type": "WorkflowRoute",
@@ -465,6 +555,26 @@
             "isExecuted": false,
             "group": null,
             "uuid": "f36e5493-2ff0-4069-a245-7b78d1d1e654"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update SLA Details -> Get SLA Details",
+            "targetStep": "\/api\/3\/workflow_steps\/0442c07a-96d8-4d43-a984-4def4fb61db1",
+            "sourceStep": "\/api\/3\/workflow_steps\/b70a1c41-8ae2-4935-b0a8-560fd87cc412",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "9c4b92db-f5eb-4435-b682-0ca9c239dd86"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Wait for Acknowledge Due Date -> Update SLA Details",
+            "targetStep": "\/api\/3\/workflow_steps\/b70a1c41-8ae2-4935-b0a8-560fd87cc412",
+            "sourceStep": "\/api\/3\/workflow_steps\/2abd1e97-4e8b-4907-9f47-e20f52ecc4a0",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "fc574799-8012-46a7-8267-f60d56c37023"
         }
     ],
     "groups": [],

--- a/playbooks/06 - IRP - Case Management/Alert - [05] Update Ack and Response Due dates (Post Severity Change).json
+++ b/playbooks/06 - IRP - Case Management/Alert - [05] Update Ack and Response Due dates (Post Severity Change).json
@@ -249,7 +249,7 @@
             "arguments": {
                 "when": "{{(vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.alertAckTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertAckTrackedOn) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertResTrackedOn)}}",
                 "resource": {
-                    "dueBy": "{%if vars.sla_time_list.alertAckTime | int ==0%} null {% elif vars.steps.Reset_Ack_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Reset_Ack_SLA.data['sla_due_date_timestamp']}}{%else%}{{vars.input.records[0].dueBy}} {%endif%}",
+                    "dueBy": "{%if vars.sla_time_list.alertAckTime | int ==0%} null {% elif vars.steps.Reset_Acknowledge_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Reset_Acknowledge_SLA.data['sla_due_date_timestamp']}}{%else%}{{vars.input.records[0].dueBy}} {%endif%}",
                     "ackSlaStatus": "{%if vars.sla_time_list.alertAckTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}"
                 },
                 "_showJson": false,
@@ -277,7 +277,7 @@
             "arguments": {
                 "when": "{{(vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.alertResTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertResTrackedOn)}}",
                 "resource": {
-                    "respDueDate": "{%if vars.sla_time_list.alertResTime | int ==0%} null {% elif vars.steps.Reset_Resp_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Reset_Resp_SLA.data['sla_due_date_timestamp']}}{%else%}{{vars.input.records[0].respDueDate}}{%endif%}",
+                    "respDueDate": "{%if vars.sla_time_list.alertResTime | int ==0%} null {% elif vars.steps.Reset_Response_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Reset_Response_SLA.data['sla_due_date_timestamp']}}{%else%}{{vars.input.records[0].respDueDate}}{%endif%}",
                     "respSlaStatus": "{%if vars.sla_time_list.alertResTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}"
                 },
                 "_showJson": false,
@@ -305,7 +305,7 @@
             "arguments": {
                 "when": "{{(vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].ackSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.alertAckTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertAckTrackedOn) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertResTrackedOn)}}",
                 "resource": {
-                    "dueBy": "{%if vars.steps.Set_Ack_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Set_Ack_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}",
+                    "dueBy": "{%if vars.steps.Set_Acknowledge_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Set_Acknowledge_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}",
                     "ackSlaStatus": "{%if vars.sla_time_list.alertAckTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}"
                 },
                 "_showJson": false,
@@ -333,7 +333,7 @@
             "arguments": {
                 "when": "{{(vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].respSlaStatus.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.alertResTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.alertResTrackedOn)}}",
                 "resource": {
-                    "respDueDate": "{%if vars.steps.Set_Resp_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Set_Resp_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}",
+                    "respDueDate": "{%if vars.steps.Set_Response_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Set_Response_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}",
                     "respSlaStatus": "{%if vars.sla_time_list.alertResTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}"
                 },
                 "_showJson": false,

--- a/playbooks/06 - IRP - Case Management/Incident - [01] Capture All SLA (Upon Create).json
+++ b/playbooks/06 - IRP - Case Management/Incident - [01] Capture All SLA (Upon Create).json
@@ -1,4 +1,5 @@
 {
+    "@context": "\/api\/3\/contexts\/Workflow",
     "@type": "Workflow",
     "triggerLimit": null,
     "name": "Incident - [01] Capture All SLA (Upon Create)",
@@ -86,8 +87,8 @@
                 "workflowReference": "\/api\/3\/workflows\/50475684-0feb-4da0-889c-7046cc6f482b"
             },
             "status": null,
-            "top": "160",
-            "left": "127",
+            "top": "165",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "5e0aafda-7422-4362-b1bc-83468488db2d"

--- a/playbooks/06 - IRP - Case Management/Incident - [02] Capture Ack SLA (Upon Update).json
+++ b/playbooks/06 - IRP - Case Management/Incident - [02] Capture Ack SLA (Upon Update).json
@@ -129,7 +129,7 @@
                     "resSla": "\/api\/3\/picklists\/3f4ef2dc-7f56-4886-b215-ee08b344cbdf",
                     "slaState": "{% if vars.input.records[0].ackDueDate < vars.input.records[0].modifyDate%}{{\"SLAState\" | picklist(\"Missed\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Paused\", \"@id\")}}{%endif%}",
                     "ackSLApausedon": "{{globalVars.Current_Date}}",
-                    "incRemainingAckSLA": "{{vars.steps.Calculate_Time_Left_for_Ack_before_Pausing.data['minutes_left'] | int}}"
+                    "incRemainingAckSLA": "{{vars.steps.Calculate_Time_Left_for_Acknowledge_before_Pausing.data['minutes_left'] | int}}"
                 },
                 "_showJson": false,
                 "operation": "Append",
@@ -182,7 +182,7 @@
                 "when": "{{(vars.input.records[0].slaState.itemValue == \"Awaiting Action\" or vars.input.records[0].slaState.itemValue == \"Paused\" ) and vars.input.records[0].status.itemValue != \"Closed\"}}",
                 "resource": {
                     "slaState": "\/api\/3\/picklists\/72979f64-e8b9-4888-a965-957e0ec24818",
-                    "ackDueDate": "{{vars.steps.Recalculate_Ack_SLA.data['sla_due_date_timestamp']}}"
+                    "ackDueDate": "{{vars.steps.Recalculate_Acknowledge_SLA.data['sla_due_date_timestamp']}}"
                 },
                 "_showJson": false,
                 "operation": "Append",

--- a/playbooks/06 - IRP - Case Management/Incident - [02] Capture Ack SLA (Upon Update).json
+++ b/playbooks/06 - IRP - Case Management/Incident - [02] Capture Ack SLA (Upon Update).json
@@ -1,4 +1,5 @@
 {
+    "@context": "\/api\/3\/contexts\/Workflow",
     "@type": "Workflow",
     "triggerLimit": null,
     "name": "Incident - [02] Capture Acknowledge SLA (Upon Update)",
@@ -35,7 +36,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "435",
+            "top": "705",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
@@ -57,7 +58,7 @@
                 "workflowReference": "\/api\/3\/workflows\/45096dd1-6f64-4f86-937f-711a1054d436"
             },
             "status": null,
-            "top": "165",
+            "top": "435",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -72,20 +73,20 @@
                     {
                         "option": "Missed",
                         "step_iri": "\/api\/3\/workflow_steps\/2259dc78-7165-4d08-8285-8e1831c67928",
-                        "condition": "{{ vars.input.records[0].modifyDate > vars.input.records[0].ackDueDate }}",
+                        "condition": "{{ vars.input.records[0].modifyDate > vars.ack_due_date }}",
                         "step_name": "Set Acknowledge SLA as Missed"
                     },
                     {
                         "option": "Met",
                         "step_iri": "\/api\/3\/workflow_steps\/22cda60d-caa6-4a99-8151-7b9daf88cb4c",
-                        "condition": "{{ vars.input.records[0].modifyDate < vars.input.records[0].ackDueDate }}",
+                        "condition": "{{ vars.input.records[0].modifyDate < vars.ack_due_date }}",
                         "step_name": "Set Acknowledge SLA as Met"
                     }
                 ],
                 "step_variables": []
             },
             "status": null,
-            "top": "570",
+            "top": "840",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -113,7 +114,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "300",
+            "top": "570",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -142,7 +143,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "570",
+            "top": "840",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -168,7 +169,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "570",
+            "top": "840",
             "left": "1000",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
@@ -195,7 +196,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "975",
             "left": "1000",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -224,7 +225,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "975",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -252,7 +253,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "975",
             "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -267,6 +268,7 @@
                 "resources": [
                     "incidents"
                 ],
+                "__triggerLimit": true,
                 "step_variables": {
                     "input": {
                         "params": [],
@@ -274,9 +276,9 @@
                             "{{vars.input.records[0]}}"
                         ]
                     },
-                    "day_today": "{{arrow.utcnow().format('dddd')}}",
-                    "alert_severity": "{{vars.input.records[0].severity.itemValue}}"
+                    "ack_due_date": "{{vars.input.records[0].ackDueDate or false}}"
                 },
+                "triggerOnSource": true,
                 "fieldbasedtrigger": {
                     "sort": [],
                     "limit": 30,
@@ -294,23 +296,23 @@
                             "operator": "changed"
                         },
                         {
-                            "type": "object",
+                            "type": "array",
                             "field": "slaState",
                             "value": [
                                 "\/api\/3\/picklists\/090115d7-90fc-4dc6-97ca-27950fc30c1c",
                                 "\/api\/3\/picklists\/5230b20c-d408-4b36-ad8f-610167d84d34"
                             ],
                             "module": "slaState",
-                            "display": "Met",
+                            "display": "",
                             "operator": "nin",
                             "template": "multiselectpicklist",
                             "OPERATOR_KEY": "$",
-                            "displayTemplate": "",
                             "previousOperator": "nin",
                             "previousTemplate": "multiselectpicklist"
                         }
                     ]
-                }
+                },
+                "triggerOnReplicate": false
             },
             "status": null,
             "top": "30",
@@ -341,11 +343,96 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "435",
+            "top": "705",
             "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "3602c56d-f354-4c9d-a7c9-48b1f29d8ae1"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update SLA Details",
+            "description": null,
+            "arguments": {
+                "when": "{{not vars.ack_due_date}}",
+                "arguments": {
+                    "severity": "{{vars.input.records[0].severity.itemValue}}",
+                    "inc_crt_dt": "{{vars.input.records[0].createDate}}",
+                    "tenant_iri": "{{vars.input.records[0].tenant['@id'] | ternary(vars.input.records[0].tenant['@id'], none)}}",
+                    "incident_id": "{{vars.input.records[0]['@id']}}"
+                },
+                "apply_async": false,
+                "step_variables": {
+                    "ack_due_date": "{{vars.steps.Update_SLA_Details.ackDueDate}}"
+                },
+                "pass_parent_env": false,
+                "pass_input_record": false,
+                "workflowReference": "\/api\/3\/workflows\/50475684-0feb-4da0-889c-7046cc6f482b"
+            },
+            "status": null,
+            "top": "300",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "b33d57dd-b898-486c-ac94-31ac90ee08de"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Wait for Acknowledge Due Date",
+            "description": null,
+            "arguments": {
+                "when": "{{not vars.ack_due_date}}",
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "uuid",
+                            "value": "{{vars.input.records[0].uuid}}",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "logic": "OR",
+                            "filters": [
+                                {
+                                    "type": "datetime",
+                                    "field": "ackDueDate",
+                                    "value": "false",
+                                    "operator": "isnull"
+                                },
+                                {
+                                    "type": "datetime",
+                                    "field": "ackDueDate",
+                                    "value": "null",
+                                    "operator": "isnull"
+                                }
+                            ]
+                        }
+                    ],
+                    "__selectFields": [
+                        "ackDueDate"
+                    ]
+                },
+                "module": "incidents?$limit=30",
+                "do_until": {
+                    "delay": 1,
+                    "retries": 30,
+                    "condition": "{{vars.steps.Wait_for_Acknowledge_Due_Date | length > 0}}"
+                },
+                "checkboxFields": true,
+                "step_variables": {
+                    "ack_due_date": "{% if vars.steps.Wait_for_Acknowledge_Due_Date | length > 0 %}{{vars.steps.Wait_for_Acknowledge_Due_Date[0].ackDueDate}}{% else %}false{% endif %}"
+                }
+            },
+            "status": null,
+            "top": "165",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "95340c5c-3e8b-4f57-ac7a-682e96a95fb7"
         }
     ],
     "routes": [
@@ -421,13 +508,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> Copy  of Get SLA Details",
-            "targetStep": "\/api\/3\/workflow_steps\/2fab9997-d562-4381-8564-145d598ec3c9",
+            "name": "Start -> Wait for Acknowledge Due Date",
+            "targetStep": "\/api\/3\/workflow_steps\/95340c5c-3e8b-4f57-ac7a-682e96a95fb7",
             "sourceStep": "\/api\/3\/workflow_steps\/30d0563e-fdaf-4ebd-b165-1b2c1437e5ad",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "72cd5342-a99c-4e12-b834-0946100d3480"
+            "uuid": "46f19683-646c-429a-97a1-fdb45b62d2e9"
         },
         {
             "@type": "WorkflowRoute",
@@ -448,6 +535,26 @@
             "isExecuted": false,
             "group": null,
             "uuid": "56e5ca89-63a0-413a-afca-521773018631"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update SLA Details -> Get SLA Details",
+            "targetStep": "\/api\/3\/workflow_steps\/2fab9997-d562-4381-8564-145d598ec3c9",
+            "sourceStep": "\/api\/3\/workflow_steps\/b33d57dd-b898-486c-ac94-31ac90ee08de",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "c6022504-cee4-4813-ac0e-72d210ec9105"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Wait for Acknowledge Due Date -> Update SLA Details",
+            "targetStep": "\/api\/3\/workflow_steps\/b33d57dd-b898-486c-ac94-31ac90ee08de",
+            "sourceStep": "\/api\/3\/workflow_steps\/95340c5c-3e8b-4f57-ac7a-682e96a95fb7",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "10de238f-2ca0-4bbf-8fce-ef29f57c0880"
         }
     ],
     "groups": [],

--- a/playbooks/06 - IRP - Case Management/Incident - [05] Update Response and Ack Due date (Post Severity Change).json
+++ b/playbooks/06 - IRP - Case Management/Incident - [05] Update Response and Ack Due date (Post Severity Change).json
@@ -250,7 +250,7 @@
                 "when": "{{(vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.incAckTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incAckTrackedOn) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incResTrackedOn)}}",
                 "resource": {
                     "slaState": "{%if vars.sla_time_list.incAckTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}",
-                    "ackDueDate": "{%if vars.sla_time_list.incAckTime | int ==0%} null {% elif vars.steps.Reset_Ack_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Reset_Ack_SLA.data['sla_due_date_timestamp']}}{%else%}{{vars.input.records[0].ackDueDate}} {%endif%}"
+                    "ackDueDate": "{%if vars.sla_time_list.incAckTime | int ==0%} null {% elif vars.steps.Reset_Acknowledge_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Reset_Acknowledge_SLA.data['sla_due_date_timestamp']}}{%else%}{{vars.input.records[0].ackDueDate}} {%endif%}"
                 },
                 "_showJson": false,
                 "operation": "Overwrite",
@@ -279,7 +279,7 @@
                 "when": "{{(vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\"))or vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.incResTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incResTrackedOn)}}",
                 "resource": {
                     "resSla": "{%if vars.sla_time_list.incResTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}",
-                    "resDueBy": "{%if vars.sla_time_list.incResTime | int ==0%} null {% elif vars.steps.Reset_Resp_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Reset_Resp_SLA.data['sla_due_date_timestamp']}}{%else%}{{vars.input.records[0].resDueBy}} {%endif%}"
+                    "resDueBy": "{%if vars.sla_time_list.incResTime | int ==0%} null {% elif vars.steps.Reset_Response_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Reset_Response_SLA.data['sla_due_date_timestamp']}}{%else%}{{vars.input.records[0].resDueBy}} {%endif%}"
                 },
                 "_showJson": false,
                 "operation": "Overwrite",
@@ -308,7 +308,7 @@
                 "when": "{{(vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\")) or vars.input.records[0].slaState.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.incAckTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incAckTrackedOn) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incResTrackedOn)}}",
                 "resource": {
                     "slaState": "{%if vars.sla_time_list.incAckTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}",
-                    "ackDueDate": "{%if vars.steps.Set_Ack_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Set_Ack_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}"
+                    "ackDueDate": "{%if vars.steps.Set_Acknowledge_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Set_Acknowledge_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}"
                 },
                 "_showJson": false,
                 "operation": "Overwrite",
@@ -337,7 +337,7 @@
                 "when": "{{(vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"Awaiting Action\", \"itemValue\"))or vars.input.records[0].resSla.itemValue == (\"SLAState\" | picklist(\"NA\", \"itemValue\"))) and (vars.sla_time_list.incResTime | int > 0) and (vars.input.records[0].status.itemValue != vars.sla_time_list.incResTrackedOn)}}",
                 "resource": {
                     "resSla": "{%if vars.sla_time_list.incResTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}",
-                    "resDueBy": "{%if vars.steps.Set_Resp_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Set_Resp_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}"
+                    "resDueBy": "{%if vars.steps.Set_Response_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Set_Response_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}"
                 },
                 "_showJson": false,
                 "operation": "Overwrite",

--- a/playbooks/06 - IRP - Case Management/Incidents - Update SLA Details.json
+++ b/playbooks/06 - IRP - Case Management/Incidents - Update SLA Details.json
@@ -176,9 +176,9 @@
                         "recordTags": "{% if vars.sla_time_list.defaultSLA %}Default SLA{% endif %}"
                     },
                     "resSla": "{%if vars.sla_time_list.incResTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}",
-                    "resDueBy": "{%if vars.steps.Calculate_Resp_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Calculate_Resp_SLA.data['sla_due_date_timestamp']}} {% else %} null {%endif%}",
+                    "resDueBy": "{%if vars.steps.Calculate_Response_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Calculate_Response_SLA.data['sla_due_date_timestamp']}} {% else %} null {%endif%}",
                     "slaState": "{%if vars.sla_time_list.incAckTime | int ==0%}{{\"SLAState\" | picklist(\"NA\", \"@id\")}}{%else%}{{\"SLAState\" | picklist(\"Awaiting Action\", \"@id\")}}{%endif%}",
-                    "ackDueDate": "{%if vars.steps.Calculate_Ack_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Calculate_Ack_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}"
+                    "ackDueDate": "{%if vars.steps.Calculate_Acknowledge_SLA.data['sla_due_date_timestamp'] %} {{vars.steps.Calculate_Acknowledge_SLA.data['sla_due_date_timestamp']}} {% else %} null {% endif%}"
                 },
                 "_showJson": false,
                 "operation": "Overwrite",

--- a/playbooks/06 - IRP - Case Management/Incidents - Update SLA Details.json
+++ b/playbooks/06 - IRP - Case Management/Incidents - Update SLA Details.json
@@ -1,4 +1,5 @@
 {
+    "@context": "\/api\/3\/contexts\/Workflow",
     "@type": "Workflow",
     "triggerLimit": null,
     "name": "Incidents - Update SLA Details",
@@ -137,7 +138,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
+            "top": "705",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
@@ -193,7 +194,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "840",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -240,13 +241,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Calculate Response SLA -> Update SLA",
-            "targetStep": "\/api\/3\/workflow_steps\/4ad0e77d-6233-4e41-a43a-ea3ea7af6e8b",
+            "name": "Calculate Response SLA -> Note for Default SLA",
+            "targetStep": "\/api\/3\/workflow_steps\/6db741d2-f8bc-4236-8435-d81948604562",
             "sourceStep": "\/api\/3\/workflow_steps\/832654c9-6fc8-4fda-8da2-87164c9a8bc0",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "6ee823fe-2425-4530-9b5f-89efb3e0df16"
+            "uuid": "0a2e41ab-fad2-4b10-a57c-c26083d89bd3"
         },
         {
             "@type": "WorkflowRoute",
@@ -260,6 +261,16 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Note for Default SLA -> Update SLA",
+            "targetStep": "\/api\/3\/workflow_steps\/4ad0e77d-6233-4e41-a43a-ea3ea7af6e8b",
+            "sourceStep": "\/api\/3\/workflow_steps\/6db741d2-f8bc-4236-8435-d81948604562",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "5cee3e92-a768-4dd6-9418-e5f1834cb5bd"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Start -> GET SLA",
             "targetStep": "\/api\/3\/workflow_steps\/e0eb888d-fdef-47cd-83fd-f6547f6b618b",
             "sourceStep": "\/api\/3\/workflow_steps\/1c8a57b8-9aa0-4730-abbd-de5ba6ea3a5f",
@@ -267,16 +278,6 @@
             "isExecuted": false,
             "group": null,
             "uuid": "ce8150e6-da04-41b6-bae4-61cf38d063a7"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Update SLA -> Note for Default SLA",
-            "targetStep": "\/api\/3\/workflow_steps\/6db741d2-f8bc-4236-8435-d81948604562",
-            "sourceStep": "\/api\/3\/workflow_steps\/4ad0e77d-6233-4e41-a43a-ea3ea7af6e8b",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "9a8da218-aea7-4c2f-822d-e2eb60e45fa4"
         },
         {
             "@type": "WorkflowRoute",

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,5 +8,5 @@
 </table>
 
 - Properly calculates **Response Due Date** and **Response SLA** when status changes (e.g., Open → Investigating → Pending → Investigating).  
-- Correctly sets **Acknowledge Due Date** if an alert moves from **Open → Closed**.  
+- Correctly sets **Acknowledge SLA** if an alert moves from **Open → Closed**.  
 - Ensures accurate **Ack Due Date** and **Ack Date** when an alert is updated to **Investigating** immediately after creation.

--- a/release_notes.md
+++ b/release_notes.md
@@ -9,4 +9,4 @@
 
 - Properly calculates **Response Due Date** and **Response SLA** when status changes (e.g., Open → Investigating → Pending → Investigating).  
 - Correctly sets **Acknowledge SLA** if an alert moves from **Open → Closed**.  
-- Ensures accurate **Ack Due Date** and **Ack Date** when an alert is updated to **Investigating** immediately after creation.
+- Ensures accurate **Ack Due Date** and **Ack Date** calculation when an alert is updated to **Investigating** immediately after creation.

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,12 @@
+# What's New
+
+<table>
+    <tr>
+        <th>Compatible Version</th>
+        <td>FortiSOAR v7.6.0 and later</td>
+    </tr>
+</table>
+
+- Properly calculates **Response Due Date** and **Response SLA** when status changes (e.g., Open → Investigating → Pending → Investigating).  
+- Correctly sets **Acknowledge Due Date** if an alert moves from **Open → Closed**.  
+- Ensures accurate **Ack Due Date** and **Ack Date** when an alert is updated to **Investigating** immediately after creation.


### PR DESCRIPTION
## Mantis#1118663
### UTCs

### 1: Playbook Waits for 'Ack Due Date' Assignment  

- **Description:** Validate that the "Alert - [02] Capture Ack SLA (Upon Update)" playbook waits until the 'Ack Due Date' field gets assigned before proceeding.  
- **Preconditions:** 
  1. The alert status updated from 'Open' to 'Investigating' right after creation

- **Steps:**  
  1. The respective playbook is triggered upon an alert or incident update
     - In Alert's case, "Alert - [02] Capture Ack SLA (Upon Update)" playbook
  2. Check if the playbook pauses execution until 'Ack Due Date' is assigned.  
- **Expected Result:** The playbook does not proceed until the 'Ack Due Date' is assigned.  

---

### 2: Playbook Calculates and Assigns 'Ack Due Date' If Not Set  

- **Description:** Validate that if the 'Ack Due Date' is not assigned, the playbook calculates and assigns an "Acknowledge Due Date" before proceeding.  
- **Preconditions:** The playbook is triggered, and 'Ack Due Date' is not initially assigned.  
- **Steps:**  
  1. The respective playbook is triggered upon an alert or incident update
     - In Alert's case, "Alert - [02] Capture Ack SLA (Upon Update)" playbook
  2. Verify that the playbook calculates and assigns 'Ack Due Date' if it is missing.  
  3. Check if the playbook continues execution after assigning the 'Ack Due Date.'  
- **Expected Result:** The playbook correctly calculates and assigns 'Ack Due Date' and proceeds with execution.