### PR TITLE
Pallavireview/2.0.0

### DIFF
--- a/info.json
+++ b/info.json
@@ -24,7 +24,7 @@
     "supportInfo": null,
     "iconLarge": null,
     "postInstallConfig": null,
-    "date": "2024-05-24T11:45:39+00:00",
+    "date": "2026-07-29T11:45:39+00:00",
     "contents": {
         "modules": {
             "alerts": {

--- a/playbooks/06 - IRP - Case Management/Case - [02] Capture Ack SLA (Upon Update).json
+++ b/playbooks/06 - IRP - Case Management/Case - [02] Capture Ack SLA (Upon Update).json
@@ -238,8 +238,8 @@
             "arguments": {
                 "when": "{{vars.input.records[0].slaState.itemValue== \"Awaiting Action\" or vars.input.records[0].slaState.itemValue == \"Paused\" or vars.input.records[0].slaState.itemValue == \"NA\"}}",
                 "resource": {
-                    "slaState": "\/api\/3\/picklists\/5230b20c-d408-4b36-ad8f-610167d84d34",
-                    "ackDueDate": "{{globalVars.Current_Date}}"
+                    "ackDate": "{{globalVars.Current_Date}}",
+                    "slaState": "\/api\/3\/picklists\/5230b20c-d408-4b36-ad8f-610167d84d34"
                 },
                 "_showJson": false,
                 "operation": "Overwrite",

--- a/release_notes.md
+++ b/release_notes.md
@@ -10,3 +10,4 @@
 - **Response Due Date** and **Response SLA** are now accurately recalculated upon changes in status (e.g., from *Open* → *Investigating* → *Pending* → *Investigating*).
 - **Acknowledge SLA** is now correctly set when an alert transitions from *Open* to *Closed*.
 - The calculation of **Ack Due Date** and **Ack Date** is now precise when an alert is updated to **Investigating** immediately after its creation.
+- Fixed an issue where the **Set Acknowledge SLA as Missed** step incorrectly updated the **Ack Due Date** field instead of the **Ack Date** field


### PR DESCRIPTION
1322268 | SLA Management: Ack due date is wrongly mapped

Description:
The issue was identified in the Incident - [02] Capture Acknowledge SLA (Upon Update) playbook.
In the [Set Acknowledge SLA as Missed update] step, the Current_Date value is incorrectly mapped to the Ack Due Date field instead of the Ack Date field.

Fixed:
- Playbook : 
06 - IRP - Case Management/Case - [02] Capture Ack SLA (Upon Update).json
Step [ Set Acknowledge SLA as Missed] , [Ack Date] is now mapped to Current date instead of [Ack Due Date]

- Updated Readme file and info.json file 

Fixed Playbook step.
Note: This fixed is derived from FSOC version 1.1.1.